### PR TITLE
fix: variant type issues  (node-opcua#1088)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "bcrypt": "5.0.1",
     "chalk": "4.1.2",
-    "node-opcua": "2.59.0",
+    "node-opcua": "2.60.2",
+    "node-opcua-server-discovery": "^2.60.0",
     "yargs": "^17.2.1"
   },
   "devDependencies": {

--- a/src/machines/machinetool/showcasemachinetool.ts
+++ b/src/machines/machinetool/showcasemachinetool.ts
@@ -14,6 +14,7 @@
 
 import { 
     coerceLocalizedText, 
+    coerceNodeId,
     DataType,
     UAVariable,
     AddressSpace,
@@ -58,8 +59,8 @@ export const createShowCaseMachineTool = async (addressSpace: AddressSpace): Pro
                 dataType: DataType.LocalizedText,
             })
             stateNumber.setValueFromSource({
-                value: 2,
-                dataType: DataType.UInt32,
+                value: coerceNodeId(2),
+                dataType: DataType.NodeId,
             })
         } else {
             state?.setValueFromSource({
@@ -67,8 +68,8 @@ export const createShowCaseMachineTool = async (addressSpace: AddressSpace): Pro
                 dataType: DataType.LocalizedText,
             })
             stateNumber.setValueFromSource({
-                value: 1,
-                dataType: DataType.UInt32,
+                value: coerceNodeId(1),
+                dataType: DataType.NodeId,
             })
         }
     }, 10000)
@@ -111,6 +112,6 @@ export const createShowCaseMachineTool = async (addressSpace: AddressSpace): Pro
     const channel1 = addressSpace?.findNode(`ns=${idx};i=55233`) as UAVariable
     channel1.setValueFromSource({
         value: 1,
-        dataType: DataType.UInt32
+        dataType: DataType.Int32
     })
 }

--- a/src/serveraddressspace/serveraddressspace.ts
+++ b/src/serveraddressspace/serveraddressspace.ts
@@ -103,12 +103,12 @@ export const createOwnServerAddressspace = async (addressSpace: AddressSpace): P
         browseName: "MySeverity",
         componentOf: dev,
         description: coerceLocalizedText("Value must be between 1000 and 100") || undefined,
-        dataType: DataType.Int32,
+        dataType: DataType.Double,
         value: {
             get: () => {
                 return new Variant({
                     value: count,
-                    dataType: DataType.Int32
+                    dataType: DataType.Double
             })},
             set: (variant: Variant) => {
                 if (variant.value > 1000 || variant.value < 100) {


### PR DESCRIPTION
 - this commit fixes some variant type mismatch that were
   not highlighted before node-opcua@2.60.2.
 - node-opcua@2.60.2 onwards now apply a strictly type checking
   to help identifying mistmatch when setValueFromSource is used
   on the server side.
 - related to node-opcua#1088 issue