### PR TITLE
feat: Switch Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM node:17.7.1-bullseye
+FROM node:17.7.1-alpine3.15
+
+RUN apk --no-cache add \
+    openssl=1.1.1l-r8 \
+    python3=3.9.7-r4 \
+    make=4.3-r0 \
+    gcc=10.3.1_git20211027-r0 \ 
+    g++=10.3.1_git20211027-r0
 
 COPY . /
 
 RUN npm install
+
+EXPOSE 4840
 
 ENTRYPOINT ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ User: `guest` Password: `pw3` Role: AuthenticatedUser
 
 Set "IP" and "PORT" in env:
 
-- `docker run -it -p 5000:5000 -e PORT=5000 -e IP=127.0.0.1 --name sampleserver-node-opcua ghcr.io/andreasheine/sampleserver-node-opcua:main`  
+- `docker run -it -p 4840:4840 -e PORT=4840 -e IP=127.0.0.1 --name sampleserver-node-opcua ghcr.io/andreasheine/sampleserver-node-opcua:main`  
   
 ## Online Server Instance  
 


### PR DESCRIPTION
Switch von `Bullseye `to `Alpine3.15`

- Shrinks the container image by about 550MB
- Fixes #120 