### PR TITLE
fix(deps): Relax alpine-openssl version to ~3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20.2.0-alpine3.17
 WORKDIR /home/node/opcua-server
 
 RUN apk --no-cache add \
-     openssl=3.0.9-r1 \
+     openssl~3 \
      python3=3.10.11-r0 \
      make=4.3-r1 \
      g++=12.2.1_git20220924-r4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20.2.0-alpine3.17
 
 WORKDIR /home/node/opcua-server
-
+# hadolint ignore=DL3018
 RUN apk --no-cache add \
      openssl~3 \
      python3=3.10.11-r0 \

--- a/LDS.Dockerfile
+++ b/LDS.Dockerfile
@@ -1,4 +1,5 @@
 FROM node:20.2.0-alpine3.17
+# hadolint ignore=DL3018
 RUN apk --no-cache add \
     openssl~3
 

--- a/LDS.Dockerfile
+++ b/LDS.Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.2.0-alpine3.17
 RUN apk --no-cache add \
-    openssl=3.0.9-r1
+    openssl~3
 
 WORKDIR /home/node/discovery
 


### PR DESCRIPTION
* fixes the different version requirements for amd64 and arm64 images