### PR TITLE
fix: Drop node 16 support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
* fixes #399
* Node 16 is EOL as of 11.09.2023
* https://nodejs.org/en/blog/announcements/nodejs16-eol