### PR TITLE
fix(ci): replace windows-2019 with windows-2025

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,8 +25,8 @@ jobs:
             ubuntu-22.04-arm,
             ubuntu-24.04,
             ubuntu-24.04-arm,
-            windows-2019,
             windows-2022,
+            windows-2025,
           ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
* The Windows 2019 Actions runner image will begin deprecation on 2025-06-01 and will be fully unsupported by 2025-06-30